### PR TITLE
Fase 1: CI/CD alineado a PHP 8.3 + README y actualización de ROADMAP

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,12 +22,12 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.3'
 
       - name: Install Dependencies
         run: |
           composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
-          npm install
+          npm ci
 
       - name: Run Pint
         run: vendor/bin/pint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    env:
+      DB_CONNECTION: sqlite
+      DB_DATABASE: database/database.sqlite
 
     steps:
       - name: Checkout
@@ -21,7 +24,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.4
+          php-version: '8.3'
           tools: composer:v2
           coverage: xdebug
 
@@ -45,6 +48,12 @@ jobs:
 
       - name: Generate Application Key
         run: php artisan key:generate
+
+      - name: Prepare SQLite and Migrate
+        run: |
+          mkdir -p database
+          touch database/database.sqlite
+          php artisan migrate --graceful --ansi
 
       - name: Tests
         run: ./vendor/bin/pest

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# Laravel 12 React Starter Kit Extension
+
+Extensión del Starter Kit oficial con React 19 + TypeScript + Inertia 2, Tailwind 4, shadcn/ui.
+
+## Requisitos
+- PHP 8.3.x (recomendado 8.3.6)
+- Node 20+ (CI usa 22)
+- Composer 2
+
+## Setup Rápido
+```bash
+composer install
+cp .env.example .env
+php artisan key:generate
+mkdir -p database && touch database/database.sqlite
+php artisan migrate --graceful
+npm ci
+npm run dev # o npm run build
+```
+
+## Ejecutar Tests (Pest v4)
+```bash
+./vendor/bin/pest
+```
+
+## Scripts útiles
+- `npm run dev`: Vite en modo desarrollo
+- `npm run build`: Build de assets
+- `npm run format`: Formateo con Prettier (resources/)
+- `npm run lint`: ESLint (JS/TS/React)
+- `composer test`: Limpia config cache y ejecuta tests
+
+## CI/CD (GitHub Actions)
+- `.github/workflows/tests.yml`
+  - PHP 8.3, Node 22
+  - Base de datos SQLite en CI (`DB_CONNECTION=sqlite`)
+  - Migra antes de correr Pest
+- `.github/workflows/lint.yml`
+  - PHP 8.3
+  - `npm ci` para instalaciones determinísticas
+  - Laravel Pint + Prettier + ESLint
+
+## Convenciones
+- Commits: Conventional Commits
+- Estilo PHP: PSR-12 (Laravel Pint)
+- TS estricto, sin `any` no tipado
+
+## Roadmap
+Ver `ROADMAP.md`. Trabajo por fases (F1–F6). Issues vinculadas en GitHub.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,10 +30,10 @@ _Objetivo: Establecer fundamentos sólidos_
 
 #### 1.3 Quality Gates
 
-- [ ] **CI/CD pipeline**: GitHub Actions con testing automático usando Pest
+- [x] **CI/CD pipeline**: GitHub Actions con testing automático usando Pest
 - [ ] **Code quality**: Pre-commit hooks (Pint ya disponible, tests automáticos)
-- [ ] **Documentation**: README inicial con setup instructions
-- [ ] **Linters Frontend**: ESLint + Prettier integrados y verificados en CI (React 19 + TypeScript)
+- [x] **Documentation**: README inicial con setup instructions
+- [x] **Linters Frontend**: ESLint + Prettier integrados y verificados en CI (React 19 + TypeScript)
 
 **Entregables Fase 1:**
 


### PR DESCRIPTION
Este PR implementa los avances de la Fase 1 según `ROADMAP.md`.

Cambios principales:
- CI/CD (GitHub Actions)
  - `tests.yml`: PHP 8.3, base de datos SQLite en CI, migraciones antes de ejecutar Pest
  - `lint.yml`: PHP 8.3 y `npm ci` para instalaciones determinísticas
- Documentación
  - `README.md`: setup local, ejecución de tests y overview de CI
  - `ROADMAP.md`: Quality Gates marcados (CI/CD, Documentation, Linters Frontend)

Checklist:
- [x] Workflows ajustados a PHP 8.3
- [x] Migraciones ejecutadas en CI antes de tests
- [x] Linters frontend integrados en CI
- [x] README inicial con instrucciones

Relacionado: #3
