### PR TITLE
Fase 2: Integración spatie/laravel-permission (roles base + HasRoles)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,7 @@
 name: linter
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - develop

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,7 @@
 name: tests
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - develop

--- a/README.md
+++ b/README.md
@@ -1,0 +1,70 @@
+# Laravel 12 React Starter Kit Extension
+
+Extensión enterprise-ready del Laravel 12 React Starter Kit oficial.
+
+- Backend: Laravel 12 (PHP 8.3)
+- Frontend: React 19 + TypeScript + Inertia v2
+- UI: Tailwind 4 + shadcn/ui
+- Testing: Pest v4 (backend), Vitest (frontend)
+
+## Requisitos
+- PHP 8.3, Composer
+- Node 22, npm 10
+
+## Setup rápido
+```bash
+cp .env.example .env
+php artisan key:generate
+
+# Instalar dependencias
+composer install
+npm ci
+
+# Compilar assets
+npm run build
+```
+
+## Base de datos (dev)
+- SQLite por defecto. Asegúrate de tener el archivo `database/database.sqlite` creado:
+```bash
+touch database/database.sqlite
+```
+
+## Comando de instalación
+Comando maestro para preparar la app. Soporta modo desarrollo para datos de ejemplo.
+
+```bash
+# Instalación base (migraciones + roles base)
+php artisan app:install
+
+# Instalación para desarrollo (además crea usuarios demo con roles)
+php artisan app:install --dev
+```
+
+Usuarios demo creados con `--dev` (password: `password`, solo dev):
+- root@demo.com → rol root
+- admin@demo.com → rol admin
+- standard@demo.com → rol standard
+
+## Testing (backend)
+```bash
+php artisan migrate --graceful
+./vendor/bin/pest
+```
+
+## CI (GitHub Actions)
+Workflows en `/.github/workflows/`:
+- tests.yml: instala deps, migra SQLite y corre Pest
+- lint.yml: Pint, ESLint y Prettier
+
+## Ramas y PRs
+- Feature branches desde `develop`.
+- CI corre en los PRs. Merge sólo con checks en verde.
+
+## Scripts npm útiles
+```bash
+npm run dev
+npm run build
+npm run lint
+npm run format
+```

--- a/README.md
+++ b/README.md
@@ -57,6 +57,32 @@ Workflows en `/.github/workflows/`:
 - tests.yml: instala deps, migra SQLite y corre Pest
 - lint.yml: Pint, ESLint y Prettier
 
+## Roles y Permisos (Spatie)
+- Paquete: `spatie/laravel-permission` integrado.
+- Props compartidas por Inertia desde `App\\Http\\Middleware\\HandleInertiaRequests`:
+  - `auth.user`: usuario autenticado
+  - `auth.roles`: string[] con los roles del usuario
+  - `auth.permissions`: string[] con permisos agregados
+
+### Ejemplo de UI (Dashboard)
+- `resources/js/pages/dashboard.tsx`: muestra los roles y un gate simple que sólo renderiza una sección si el usuario tiene rol `admin` o `root`.
+
+### Ruta protegida por rol
+- Ruta de ejemplo en `routes/web.php` dentro del grupo `auth` + `verified`:
+
+```php
+Route::get('admin-only', function () {
+    return response('Admin area', 200);
+})->middleware(['role:admin|root'])->name('admin.only');
+```
+
+### Middlewares registrados
+- En `bootstrap/app.php` se registran los alias de Spatie:
+  - `role`, `permission`, `role_or_permission`.
+
+### Comando de instalación y caché de permisos
+- `php artisan app:install` ejecuta `permission:cache-reset` al final para limpiar la caché de permisos/roles.
+
 ## Ramas y PRs
 - Feature branches desde `develop`.
 - CI corre en los PRs. Merge sólo con checks en verde.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,10 +30,10 @@ _Objetivo: Establecer fundamentos sólidos_
 
 #### 1.3 Quality Gates
 
-- [ ] **CI/CD pipeline**: GitHub Actions con testing automático usando Pest
+- [x] **CI/CD pipeline**: GitHub Actions con testing automático usando Pest
 - [ ] **Code quality**: Pre-commit hooks (Pint ya disponible, tests automáticos)
-- [ ] **Documentation**: README inicial con setup instructions
-- [ ] **Linters Frontend**: ESLint + Prettier integrados y verificados en CI (React 19 + TypeScript)
+- [x] **Documentation**: README inicial con setup instructions
+- [x] **Linters Frontend**: ESLint + Prettier integrados y verificados en CI (React 19 + TypeScript)
 
 **Entregables Fase 1:**
 
@@ -51,10 +51,10 @@ _Objetivo: Implementar gestión avanzada de roles y permisos_
 
 #### 2.1 Spatie Permission Integration
 
-- [ ] **Instalación**: `composer require spatie/laravel-permission`
-- [ ] **Migraciones**: Crear estructura de roles y permisos
-- [ ] **Seeders**: BaseSystemSeeder con roles (root, admin, standard)
-- [ ] **Models**: Extender User model con traits de permission
+- [x] **Instalación**: `composer require spatie/laravel-permission`
+- [x] **Migraciones**: Crear estructura de roles y permisos
+- [x] **Seeders**: BaseSystemSeeder con roles (root, admin, standard)
+- [x] **Models**: Extender User model con traits de permission
 
 #### 2.2 Backend Implementation
 

--- a/app/Console/Commands/AppInstall.php
+++ b/app/Console/Commands/AppInstall.php
@@ -67,6 +67,9 @@ class AppInstall extends Command
             $this->info('Usuarios demo creados con contraseña por defecto: "password"');
         }
 
+        // Resetear caché de permisos/roles
+        $this->call('permission:cache-reset');
+
         $this->info('Instalación completada.');
         return self::SUCCESS;
     }

--- a/app/Console/Commands/AppInstall.php
+++ b/app/Console/Commands/AppInstall.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Hash;
+use App\Models\User;
+use Spatie\Permission\Models\Role;
+
+class AppInstall extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:install {--dev : Seed de datos de ejemplo (usuarios demo y roles asignados)}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Instalación base del sistema: migraciones, seeds y (opcional) datos de desarrollo';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $this->info('Iniciando instalación base...');
+
+        // 1) Migraciones
+        $this->call('migrate', ['--graceful' => true]);
+
+        // 2) Seed base del sistema (roles)
+        $this->call('db:seed', [
+            '--class' => 'Database\\Seeders\\BaseSystemSeeder',
+            '--no-interaction' => true,
+        ]);
+
+        // 3) Si --dev, crear usuarios demo y asignar roles
+        if ($this->option('dev')) {
+            $this->line('Creando usuarios demo (--dev)...');
+
+            $demoUsers = [
+                ['email' => 'root@demo.com', 'name' => 'Root User', 'role' => 'root'],
+                ['email' => 'admin@demo.com', 'name' => 'Admin User', 'role' => 'admin'],
+                ['email' => 'standard@demo.com', 'name' => 'Standard User', 'role' => 'standard'],
+            ];
+
+            foreach ($demoUsers as $data) {
+                $user = User::firstOrCreate(
+                    ['email' => $data['email']],
+                    [
+                        'name' => $data['name'],
+                        'password' => Hash::make('password'), // Solo dev
+                    ]
+                );
+
+                // Asegurar que el rol exista (por si el seeder fue alterado)
+                $role = Role::firstOrCreate(['name' => $data['role'], 'guard_name' => 'web']);
+                $user->syncRoles([$role->name]);
+            }
+
+            $this->info('Usuarios demo creados con contraseña por defecto: "password"');
+        }
+
+        $this->info('Instalación completada.');
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -37,13 +37,17 @@ class HandleInertiaRequests extends Middleware
     public function share(Request $request): array
     {
         [$message, $author] = str(Inspiring::quotes()->random())->explode('-');
+        $user = $request->user();
 
         return [
             ...parent::share($request),
             'name' => config('app.name'),
             'quote' => ['message' => trim($message), 'author' => trim($author)],
             'auth' => [
-                'user' => $request->user(),
+                'user' => $user,
+                // Roles y permisos compartidos para el frontend
+                'roles' => $user ? $user->getRoleNames()->toArray() : [],
+                'permissions' => $user ? $user->getAllPermissions()->pluck('name')->toArray() : [],
             ],
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
         ];

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,11 +6,12 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory, Notifiable, HasRoles;
 
     /**
      * The attributes that are mass assignable.

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -6,6 +6,9 @@ use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
+use Spatie\Permission\Middleware\PermissionMiddleware;
+use Spatie\Permission\Middleware\RoleMiddleware;
+use Spatie\Permission\Middleware\RoleOrPermissionMiddleware;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -20,6 +23,13 @@ return Application::configure(basePath: dirname(__DIR__))
             HandleAppearance::class,
             HandleInertiaRequests::class,
             AddLinkHeadersForPreloadedAssets::class,
+        ]);
+
+        // Aliases para middlewares de Spatie Permission
+        $middleware->alias([
+            'role' => RoleMiddleware::class,
+            'permission' => PermissionMiddleware::class,
+            'role_or_permission' => RoleOrPermissionMiddleware::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "inertiajs/inertia-laravel": "^2.0",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",
-        "laravel/wayfinder": "^0.1.9"
+        "laravel/wayfinder": "^0.1.9",
+        "spatie/laravel-permission": "^6.21"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b32a9224e608621384f6fb3318b83ead",
+    "content-hash": "b6f0ba7883c9bc40b93f1fb365e70699",
     "packages": [
         {
             "name": "brick/math",
@@ -3405,6 +3405,89 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.9.0"
             },
             "time": "2025-06-25T14:20:11+00:00"
+        },
+        {
+            "name": "spatie/laravel-permission",
+            "version": "6.21.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-permission.git",
+                "reference": "6a118e8855dfffcd90403aab77bbf35a03db51b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-permission/zipball/6a118e8855dfffcd90403aab77bbf35a03db51b3",
+                "reference": "6a118e8855dfffcd90403aab77bbf35a03db51b3",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/auth": "^8.12|^9.0|^10.0|^11.0|^12.0",
+                "illuminate/container": "^8.12|^9.0|^10.0|^11.0|^12.0",
+                "illuminate/contracts": "^8.12|^9.0|^10.0|^11.0|^12.0",
+                "illuminate/database": "^8.12|^9.0|^10.0|^11.0|^12.0",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "laravel/passport": "^11.0|^12.0",
+                "laravel/pint": "^1.0",
+                "orchestra/testbench": "^6.23|^7.0|^8.0|^9.0|^10.0",
+                "phpunit/phpunit": "^9.4|^10.1|^11.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\Permission\\PermissionServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "6.x-dev",
+                    "dev-master": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Spatie\\Permission\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Permission handling for Laravel 8.0 and up",
+            "homepage": "https://github.com/spatie/laravel-permission",
+            "keywords": [
+                "acl",
+                "laravel",
+                "permission",
+                "permissions",
+                "rbac",
+                "roles",
+                "security",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-permission/issues",
+                "source": "https://github.com/spatie/laravel-permission/tree/6.21.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-07-23T16:08:05+00:00"
         },
         {
             "name": "symfony/clock",

--- a/config/permission.php
+++ b/config/permission.php
@@ -1,0 +1,202 @@
+<?php
+
+return [
+
+    'models' => [
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * Eloquent model should be used to retrieve your permissions. Of course, it
+         * is often just the "Permission" model but you may use whatever you like.
+         *
+         * The model you want to use as a Permission model needs to implement the
+         * `Spatie\Permission\Contracts\Permission` contract.
+         */
+
+        'permission' => Spatie\Permission\Models\Permission::class,
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * Eloquent model should be used to retrieve your roles. Of course, it
+         * is often just the "Role" model but you may use whatever you like.
+         *
+         * The model you want to use as a Role model needs to implement the
+         * `Spatie\Permission\Contracts\Role` contract.
+         */
+
+        'role' => Spatie\Permission\Models\Role::class,
+
+    ],
+
+    'table_names' => [
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your roles. We have chosen a basic
+         * default value but you may easily change it to any table you like.
+         */
+
+        'roles' => 'roles',
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * table should be used to retrieve your permissions. We have chosen a basic
+         * default value but you may easily change it to any table you like.
+         */
+
+        'permissions' => 'permissions',
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * table should be used to retrieve your models permissions. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'model_has_permissions' => 'model_has_permissions',
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your models roles. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'model_has_roles' => 'model_has_roles',
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your roles permissions. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'role_has_permissions' => 'role_has_permissions',
+    ],
+
+    'column_names' => [
+        /*
+         * Change this if you want to name the related pivots other than defaults
+         */
+        'role_pivot_key' => null, // default 'role_id',
+        'permission_pivot_key' => null, // default 'permission_id',
+
+        /*
+         * Change this if you want to name the related model primary key other than
+         * `model_id`.
+         *
+         * For example, this would be nice if your primary keys are all UUIDs. In
+         * that case, name this `model_uuid`.
+         */
+
+        'model_morph_key' => 'model_id',
+
+        /*
+         * Change this if you want to use the teams feature and your related model's
+         * foreign key is other than `team_id`.
+         */
+
+        'team_foreign_key' => 'team_id',
+    ],
+
+    /*
+     * When set to true, the method for checking permissions will be registered on the gate.
+     * Set this to false if you want to implement custom logic for checking permissions.
+     */
+
+    'register_permission_check_method' => true,
+
+    /*
+     * When set to true, Laravel\Octane\Events\OperationTerminated event listener will be registered
+     * this will refresh permissions on every TickTerminated, TaskTerminated and RequestTerminated
+     * NOTE: This should not be needed in most cases, but an Octane/Vapor combination benefited from it.
+     */
+    'register_octane_reset_listener' => false,
+
+    /*
+     * Events will fire when a role or permission is assigned/unassigned:
+     * \Spatie\Permission\Events\RoleAttached
+     * \Spatie\Permission\Events\RoleDetached
+     * \Spatie\Permission\Events\PermissionAttached
+     * \Spatie\Permission\Events\PermissionDetached
+     *
+     * To enable, set to true, and then create listeners to watch these events.
+     */
+    'events_enabled' => false,
+
+    /*
+     * Teams Feature.
+     * When set to true the package implements teams using the 'team_foreign_key'.
+     * If you want the migrations to register the 'team_foreign_key', you must
+     * set this to true before doing the migration.
+     * If you already did the migration then you must make a new migration to also
+     * add 'team_foreign_key' to 'roles', 'model_has_roles', and 'model_has_permissions'
+     * (view the latest version of this package's migration file)
+     */
+
+    'teams' => false,
+
+    /*
+     * The class to use to resolve the permissions team id
+     */
+    'team_resolver' => \Spatie\Permission\DefaultTeamResolver::class,
+
+    /*
+     * Passport Client Credentials Grant
+     * When set to true the package will use Passports Client to check permissions
+     */
+
+    'use_passport_client_credentials' => false,
+
+    /*
+     * When set to true, the required permission names are added to exception messages.
+     * This could be considered an information leak in some contexts, so the default
+     * setting is false here for optimum safety.
+     */
+
+    'display_permission_in_exception' => false,
+
+    /*
+     * When set to true, the required role names are added to exception messages.
+     * This could be considered an information leak in some contexts, so the default
+     * setting is false here for optimum safety.
+     */
+
+    'display_role_in_exception' => false,
+
+    /*
+     * By default wildcard permission lookups are disabled.
+     * See documentation to understand supported syntax.
+     */
+
+    'enable_wildcard_permission' => false,
+
+    /*
+     * The class to use for interpreting wildcard permissions.
+     * If you need to modify delimiters, override the class and specify its name here.
+     */
+    // 'wildcard_permission' => Spatie\Permission\WildcardPermission::class,
+
+    /* Cache-specific settings */
+
+    'cache' => [
+
+        /*
+         * By default all permissions are cached for 24 hours to speed up performance.
+         * When permissions or roles are updated the cache is flushed automatically.
+         */
+
+        'expiration_time' => \DateInterval::createFromDateString('24 hours'),
+
+        /*
+         * The cache key used to store all permissions.
+         */
+
+        'key' => 'spatie.permission.cache',
+
+        /*
+         * You may optionally indicate a specific cache driver to use for permission and
+         * role caching using any of the `store` drivers listed in the cache.php config
+         * file. Using 'default' here means to use the `default` set in cache.php.
+         */
+
+        'store' => 'default',
+    ],
+];

--- a/database/migrations/2025_09_01_215206_create_permission_tables.php
+++ b/database/migrations/2025_09_01_215206_create_permission_tables.php
@@ -1,0 +1,136 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $teams = config('permission.teams');
+        $tableNames = config('permission.table_names');
+        $columnNames = config('permission.column_names');
+        $pivotRole = $columnNames['role_pivot_key'] ?? 'role_id';
+        $pivotPermission = $columnNames['permission_pivot_key'] ?? 'permission_id';
+
+        throw_if(empty($tableNames), new Exception('Error: config/permission.php not loaded. Run [php artisan config:clear] and try again.'));
+        throw_if($teams && empty($columnNames['team_foreign_key'] ?? null), new Exception('Error: team_foreign_key on config/permission.php not loaded. Run [php artisan config:clear] and try again.'));
+
+        Schema::create($tableNames['permissions'], static function (Blueprint $table) {
+            // $table->engine('InnoDB');
+            $table->bigIncrements('id'); // permission id
+            $table->string('name');       // For MyISAM use string('name', 225); // (or 166 for InnoDB with Redundant/Compact row format)
+            $table->string('guard_name'); // For MyISAM use string('guard_name', 25);
+            $table->timestamps();
+
+            $table->unique(['name', 'guard_name']);
+        });
+
+        Schema::create($tableNames['roles'], static function (Blueprint $table) use ($teams, $columnNames) {
+            // $table->engine('InnoDB');
+            $table->bigIncrements('id'); // role id
+            if ($teams || config('permission.testing')) { // permission.testing is a fix for sqlite testing
+                $table->unsignedBigInteger($columnNames['team_foreign_key'])->nullable();
+                $table->index($columnNames['team_foreign_key'], 'roles_team_foreign_key_index');
+            }
+            $table->string('name');       // For MyISAM use string('name', 225); // (or 166 for InnoDB with Redundant/Compact row format)
+            $table->string('guard_name'); // For MyISAM use string('guard_name', 25);
+            $table->timestamps();
+            if ($teams || config('permission.testing')) {
+                $table->unique([$columnNames['team_foreign_key'], 'name', 'guard_name']);
+            } else {
+                $table->unique(['name', 'guard_name']);
+            }
+        });
+
+        Schema::create($tableNames['model_has_permissions'], static function (Blueprint $table) use ($tableNames, $columnNames, $pivotPermission, $teams) {
+            $table->unsignedBigInteger($pivotPermission);
+
+            $table->string('model_type');
+            $table->unsignedBigInteger($columnNames['model_morph_key']);
+            $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_permissions_model_id_model_type_index');
+
+            $table->foreign($pivotPermission)
+                ->references('id') // permission id
+                ->on($tableNames['permissions'])
+                ->onDelete('cascade');
+            if ($teams) {
+                $table->unsignedBigInteger($columnNames['team_foreign_key']);
+                $table->index($columnNames['team_foreign_key'], 'model_has_permissions_team_foreign_key_index');
+
+                $table->primary([$columnNames['team_foreign_key'], $pivotPermission, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_permissions_permission_model_type_primary');
+            } else {
+                $table->primary([$pivotPermission, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_permissions_permission_model_type_primary');
+            }
+
+        });
+
+        Schema::create($tableNames['model_has_roles'], static function (Blueprint $table) use ($tableNames, $columnNames, $pivotRole, $teams) {
+            $table->unsignedBigInteger($pivotRole);
+
+            $table->string('model_type');
+            $table->unsignedBigInteger($columnNames['model_morph_key']);
+            $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_roles_model_id_model_type_index');
+
+            $table->foreign($pivotRole)
+                ->references('id') // role id
+                ->on($tableNames['roles'])
+                ->onDelete('cascade');
+            if ($teams) {
+                $table->unsignedBigInteger($columnNames['team_foreign_key']);
+                $table->index($columnNames['team_foreign_key'], 'model_has_roles_team_foreign_key_index');
+
+                $table->primary([$columnNames['team_foreign_key'], $pivotRole, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_roles_role_model_type_primary');
+            } else {
+                $table->primary([$pivotRole, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_roles_role_model_type_primary');
+            }
+        });
+
+        Schema::create($tableNames['role_has_permissions'], static function (Blueprint $table) use ($tableNames, $pivotRole, $pivotPermission) {
+            $table->unsignedBigInteger($pivotPermission);
+            $table->unsignedBigInteger($pivotRole);
+
+            $table->foreign($pivotPermission)
+                ->references('id') // permission id
+                ->on($tableNames['permissions'])
+                ->onDelete('cascade');
+
+            $table->foreign($pivotRole)
+                ->references('id') // role id
+                ->on($tableNames['roles'])
+                ->onDelete('cascade');
+
+            $table->primary([$pivotPermission, $pivotRole], 'role_has_permissions_permission_id_role_id_primary');
+        });
+
+        app('cache')
+            ->store(config('permission.cache.store') != 'default' ? config('permission.cache.store') : null)
+            ->forget(config('permission.cache.key'));
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $tableNames = config('permission.table_names');
+
+        if (empty($tableNames)) {
+            throw new \Exception('Error: config/permission.php not found and defaults could not be merged. Please publish the package configuration before proceeding, or drop the tables manually.');
+        }
+
+        Schema::drop($tableNames['role_has_permissions']);
+        Schema::drop($tableNames['model_has_roles']);
+        Schema::drop($tableNames['model_has_permissions']);
+        Schema::drop($tableNames['roles']);
+        Schema::drop($tableNames['permissions']);
+    }
+};

--- a/database/seeders/BaseSystemSeeder.php
+++ b/database/seeders/BaseSystemSeeder.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Role;
+
+class BaseSystemSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Roles base del sistema
+        $roles = [
+            'root',
+            'admin',
+            'standard',
+        ];
+
+        foreach ($roles as $name) {
+            Role::firstOrCreate([
+                'name' => $name,
+                'guard_name' => 'web',
+            ]);
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,11 +13,16 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+        // Semillas base del sistema (roles, permisos, etc.)
+        $this->call([
+            BaseSystemSeeder::class,
         ]);
+
+        // Datos de ejemplo mínimos (opcional)
+        // User::factory(10)->create();
+        // User::factory()->create([
+        //     'name' => 'Test User',
+        //     'email' => 'test@example.com',
+        // ]);
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\User;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
 
 class DatabaseSeeder extends Seeder
 {
@@ -18,11 +19,18 @@ class DatabaseSeeder extends Seeder
             BaseSystemSeeder::class,
         ]);
 
-        // Datos de ejemplo mínimos (opcional)
-        // User::factory(10)->create();
-        // User::factory()->create([
-        //     'name' => 'Test User',
-        //     'email' => 'test@example.com',
-        // ]);
+        // Usuario inicial solo en entornos local / testing
+        if (app()->environment(['local', 'testing'])) {
+            $user = User::firstOrCreate(
+                ['email' => 'admin@local.test'],
+                [
+                    'name' => 'Local Admin',
+                    'password' => Hash::make('password'),
+                ]
+            );
+
+            // Asignar rol "admin" (creado por BaseSystemSeeder)
+            $user->syncRoles(['admin']);
+        }
     }
 }

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -1,8 +1,8 @@
 import { PlaceholderPattern } from '@/components/ui/placeholder-pattern';
 import AppLayout from '@/layouts/app-layout';
 import { dashboard } from '@/routes';
-import { type BreadcrumbItem } from '@/types';
-import { Head } from '@inertiajs/react';
+import { type Auth, type BreadcrumbItem } from '@/types';
+import { Head, usePage } from '@inertiajs/react';
 
 const breadcrumbs: BreadcrumbItem[] = [
     {
@@ -12,6 +12,9 @@ const breadcrumbs: BreadcrumbItem[] = [
 ];
 
 export default function Dashboard() {
+    const { auth } = usePage<{ auth: Auth }>().props;
+    const roles = auth?.roles ?? [];
+
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="Dashboard" />
@@ -30,6 +33,35 @@ export default function Dashboard() {
                 <div className="relative min-h-[100vh] flex-1 overflow-hidden rounded-xl border border-sidebar-border/70 md:min-h-min dark:border-sidebar-border">
                     <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
                 </div>
+
+                {/* Roles actuales */}
+                <div className="rounded-md border border-sidebar-border/70 p-4 text-sm dark:border-sidebar-border">
+                    <div className="mb-2 font-medium">Tus roles</div>
+                    {roles.length > 0 ? (
+                        <div className="flex flex-wrap gap-2">
+                            {roles.map((r) => (
+                                <span
+                                    key={r}
+                                    className="inline-flex items-center rounded-md border px-2 py-1 text-xs font-medium text-foreground/90 border-sidebar-border/70 dark:border-sidebar-border"
+                                >
+                                    {r}
+                                </span>
+                            ))}
+                        </div>
+                    ) : (
+                        <div className="text-foreground/60">Sin roles asignados</div>
+                    )}
+                </div>
+
+                {/* Gate simple por rol */}
+                {(roles.includes('admin') || roles.includes('root')) && (
+                    <div className="rounded-md border border-emerald-500/40 bg-emerald-500/5 p-4 text-sm">
+                        <div className="font-medium text-emerald-600 dark:text-emerald-400">Sección visible solo para admin/root</div>
+                        <p className="mt-1 text-foreground/70">
+                            Este bloque se renderiza cuando el usuario tiene el rol <code>admin</code> o <code>root</code>.
+                        </p>
+                    </div>
+                )}
             </div>
         </AppLayout>
     );

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -3,6 +3,8 @@ import { LucideIcon } from 'lucide-react';
 
 export interface Auth {
     user: User;
+    roles: string[];
+    permissions: string[];
 }
 
 export interface BreadcrumbItem {

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,6 +11,11 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('dashboard', function () {
         return Inertia::render('dashboard');
     })->name('dashboard');
+
+    // Ruta de ejemplo protegida por roles (admin o root)
+    Route::get('admin-only', function () {
+        return response('Admin area', 200);
+    })->middleware(['role:admin|root'])->name('admin.only');
 });
 
 require __DIR__.'/settings.php';

--- a/tests/Feature/Permissions/AdminOnlyRouteTest.php
+++ b/tests/Feature/Permissions/AdminOnlyRouteTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Models\User;
+use Database\Seeders\BaseSystemSeeder;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+use function Pest\Laravel\artisan;
+
+it('permite acceso a /admin-only para usuario con rol admin', function () {
+    // Seed base roles
+    artisan('db:seed', ['--class' => BaseSystemSeeder::class, '--no-interaction' => true])->assertSuccessful();
+
+    $user = User::factory()->create([
+        'email_verified_at' => now(),
+    ]);
+
+    // Asignar rol admin
+    $user->syncRoles(['admin']);
+
+    actingAs($user);
+
+    get(route('admin.only'))
+        ->assertOk()
+        ->assertSee('Admin area');
+});
+
+it('deniega acceso a /admin-only para usuario sin rol requerido', function () {
+    // Seed base roles (no se asignará ninguno al usuario)
+    artisan('db:seed', ['--class' => BaseSystemSeeder::class, '--no-interaction' => true])->assertSuccessful();
+
+    $user = User::factory()->create([
+        'email_verified_at' => now(),
+    ]);
+    // Usuario sin roles
+
+    actingAs($user);
+
+    get(route('admin.only'))
+        ->assertForbidden();
+});

--- a/tests/Feature/Permissions/AppInstallCommandTest.php
+++ b/tests/Feature/Permissions/AppInstallCommandTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Models\User;
+
+use function Pest\Laravel\artisan;
+
+it('app:install --dev crea usuarios demo con roles asignados', function () {
+    // Act
+    artisan('app:install', ['--dev' => true])->assertSuccessful();
+
+    // Assert usuarios
+    $root = User::whereEmail('root@demo.com')->first();
+    $admin = User::whereEmail('admin@demo.com')->first();
+    $standard = User::whereEmail('standard@demo.com')->first();
+
+    expect($root)->not->toBeNull();
+    expect($admin)->not->toBeNull();
+    expect($standard)->not->toBeNull();
+
+    // Assert roles
+    expect($root->hasRole('root'))->toBeTrue();
+    expect($admin->hasRole('admin'))->toBeTrue();
+    expect($standard->hasRole('standard'))->toBeTrue();
+});

--- a/tests/Feature/Permissions/BaseSystemSeederTest.php
+++ b/tests/Feature/Permissions/BaseSystemSeederTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use Database\Seeders\BaseSystemSeeder;
+use Spatie\Permission\Models\Role;
+
+use function Pest\Laravel\artisan;
+
+it('crea los roles base root, admin y standard', function () {
+    // Act
+    artisan('db:seed', [
+        '--class' => BaseSystemSeeder::class,
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    // Assert
+    expect(Role::where('name', 'root')->exists())->toBeTrue();
+    expect(Role::where('name', 'admin')->exists())->toBeTrue();
+    expect(Role::where('name', 'standard')->exists())->toBeTrue();
+
+    // Bonus: exactamente 3 roles creados si la BD estaba vacía
+    expect(Role::count())->toBeGreaterThanOrEqual(3);
+});

--- a/tests/Feature/Permissions/DatabaseSeederInitialUserTest.php
+++ b/tests/Feature/Permissions/DatabaseSeederInitialUserTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use App\Models\User;
+
+use function Pest\Laravel\artisan;
+
+it('DatabaseSeeder crea usuario admin@local.test con rol admin en entorno testing', function () {
+    // Act: corre el seeder principal
+    artisan('db:seed', ['--no-interaction' => true])->assertSuccessful();
+
+    // Assert usuario
+    $user = User::whereEmail('admin@local.test')->first();
+    expect($user)->not->toBeNull();
+    
+    // Assert rol asignado
+    expect($user->hasRole('admin'))->toBeTrue();
+});


### PR DESCRIPTION
Este PR integra `spatie/laravel-permission` como base del sistema de roles/permisos.

Cambios:
- Dependencia: `spatie/laravel-permission`
- Publicado: `config/permission.php` y migración base de permisos
- Migraciones: ejecutadas en local (CI las ejecutará también)
- Seeder: `BaseSystemSeeder` crea roles `root`, `admin`, `standard`
- Seeder principal: `DatabaseSeeder` llama a `BaseSystemSeeder`
- Modelo: `User` ahora usa `HasRoles`

Checklist:
- [x] Paquete instalado y configurado
- [x] Migraciones publicadas
- [x] Roles base creados por seeder
- [x] User extendido con HasRoles

Siguientes pasos (subtareas):
- [ ] Asignar rol inicial a un usuario en seeding (e.g., `root`)
- [ ] Feature tests (Pest) para comprobación de roles
- [ ] UI mínima para visualizar rol actual en layout/dashboard

Relacionado: #4
