### PR TITLE
docs: centralize docs into /docs and link from README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,27 @@
-name: tests (manual)
+name: ci
 
-# Nota: Pipeline unificado en .github/workflows/ci.yml
-# Este workflow queda sólo para ejecución manual cuando sea necesario.
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - develop
+      - main
+      - 'feature/**'
+      - 'docs/**'
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
+  pull_request:
+    branches:
+      - develop
+      - main
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   ci:
@@ -11,7 +29,6 @@ jobs:
     env:
       DB_CONNECTION: sqlite
       DB_DATABASE: database/database.sqlite
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,11 +46,10 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
-      - name: Install Node Dependencies
-        run: npm ci
-
       - name: Install Dependencies
-        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+        run: |
+          composer install --no-interaction --prefer-dist --optimize-autoloader
+          npm ci
 
       - name: Build Assets
         run: npm run build
@@ -50,5 +66,11 @@ jobs:
           touch database/database.sqlite
           php artisan migrate --graceful --ansi
 
-      - name: Tests
+      - name: PHP Style (Pint)
+        run: vendor/bin/pint --test
+
+      - name: Frontend Lint (ESLint)
+        run: npm run lint
+
+      - name: Tests (Pest)
         run: ./vendor/bin/pest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,15 +1,9 @@
-name: linter
+name: linter (manual)
 
+# Nota: Pipeline unificado en .github/workflows/ci.yml
+# Este workflow queda sólo para ejecución manual cuando sea necesario.
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - develop
-      - main
-  pull_request:
-    branches:
-      - develop
-      - main
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Usuarios demo creados con `--dev` (password: `password`, solo dev):
   - `auth.roles`: string[] con los roles del usuario
   - `auth.permissions`: string[] con permisos agregados
 
+Documentación completa: `docs/permissions.md`.
+
 ### Ejemplo de UI (Dashboard)
 - `resources/js/pages/dashboard.tsx`: muestra los roles y un gate simple que sólo renderiza una sección si el usuario tiene rol `admin` o `root`.
 
@@ -95,3 +97,9 @@ Route::get('admin-only', function () {
 
 ## Roadmap
 Ver `ROADMAP.md`. Trabajo por fases (F1–F6). Issues vinculadas en GitHub.
+
+## Documentación
+- `docs/permissions.md`: Roles y permisos (Spatie)
+- `docs/testing.md`: Testing (Pest, coverage, component tests)
+- `docs/ci-cd.md`: CI/CD (Actions, checks requeridos, branch protection)
+- `docs/frontend.md`: Frontend (Inertia 2, shadcn/ui, Tailwind 4)

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -1,0 +1,39 @@
+# CI/CD (GitHub Actions)
+
+Guía para pipelines estables y rápidos.
+
+## Workflows
+- `/.github/workflows/tests.yml`
+  - PHP 8.3, Node 22
+  - `composer install`, `npm ci`, build, `.env`, `php artisan key:generate`
+  - SQLite in-memory/file y `php artisan migrate --graceful`
+  - `./vendor/bin/pest`
+- `/.github/workflows/lint.yml`
+  - Pint, Prettier, ESLint
+
+Ambos soportan `workflow_dispatch` para ejecución manual.
+
+## Required checks
+Configura en GitHub → Settings → Branches → Branch protection rules (develop/main):
+- Require status checks to pass before merging
+  - Selecciona: `tests`, `linter`
+- Require linear history (opcional)
+- Require pull request reviews before merging (opcional)
+
+## Estrategia de ramas
+- `main`: estable, releases
+- `develop`: integración diaria
+- `feature/*`: cambios pequeños (1–2 días). Rebase contra `develop` frecuente.
+
+## Consejos de rendimiento
+- Usa caches de `actions/setup-node` y Composer si aumenta el tiempo de pipeline
+- Evita instalar dev tools innecesarios
+- Ejecuta `npm run build` en tests.yml sólo si hay cambios en frontend (regla opcional)
+
+## Troubleshooting
+- Checks no aparecen en el PR pero Actions está verde:
+  - Asegura “Required checks” configurados (arriba)
+  - Ejecuta manualmente con `workflow_dispatch`
+  - Cierra/reabre el PR o haz un commit vacío para re-disparar
+- Permisos:
+  - Settings → Actions → General: Allow all actions; GITHUB_TOKEN con read/write si lo requiere tu workflow

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -1,39 +1,41 @@
 # CI/CD (GitHub Actions)
 
-Guía para pipelines estables y rápidos.
+Pipeline unificado, rápido y simple para trabajo en solitario.
 
-## Workflows
-- `/.github/workflows/tests.yml`
-  - PHP 8.3, Node 22
-  - `composer install`, `npm ci`, build, `.env`, `php artisan key:generate`
-  - SQLite in-memory/file y `php artisan migrate --graceful`
-  - `./vendor/bin/pest`
-- `/.github/workflows/lint.yml`
-  - Pint, Prettier, ESLint
+## Workflow único
+- `/.github/workflows/ci.yml` (único status: `ci`)
+  - Dispara en `push` y `pull_request` para `develop`, `main`, `feature/**`, `docs/**`.
+  - Ignora cambios en `docs/**` y `README.md` (no corre CI pesado para docs-only).
+  - Concurrency: cancela ejecuciones previas en la misma rama.
+  - Pasos:
+    - PHP 8.3 + Node 22
+    - Composer + npm ci
+    - Build de assets
+    - `.env` + `key:generate`
+    - Migraciones SQLite (`migrate --graceful`)
+    - Pint `--test`, ESLint, Pest
 
-Ambos soportan `workflow_dispatch` para ejecución manual.
+Workflows previos quedan manuales:
+- `/.github/workflows/tests.yml` y `/.github/workflows/lint.yml` → sólo `workflow_dispatch` por si necesitas ejecutarlos aislados.
 
-## Required checks
+## Required checks (Branch protection)
 Configura en GitHub → Settings → Branches → Branch protection rules (develop/main):
-- Require status checks to pass before merging
-  - Selecciona: `tests`, `linter`
-- Require linear history (opcional)
-- Require pull request reviews before merging (opcional)
+- Require status checks to pass before merging → Selecciona solo: `ci`.
+- Enable auto-merge (opcional) para que los PRs se fusionen automáticamente al pasar `ci`.
+- Require linear history (opcional).
 
 ## Estrategia de ramas
-- `main`: estable, releases
-- `develop`: integración diaria
-- `feature/*`: cambios pequeños (1–2 días). Rebase contra `develop` frecuente.
+- `develop`: rama de integración. Commits directos permitidos si el cambio es pequeño.
+- `feature/*`: para features medianas; máximo 1 PR abierto. Rebase frecuente.
+- `docs/*`: cambios de documentación.
 
-## Consejos de rendimiento
-- Usa caches de `actions/setup-node` y Composer si aumenta el tiempo de pipeline
-- Evita instalar dev tools innecesarios
-- Ejecuta `npm run build` en tests.yml sólo si hay cambios en frontend (regla opcional)
+## Tips de rendimiento
+- Usa `[skip ci]` en commits triviales de docs si no quieres correr CI.
+- Mantén dependencias al mínimo y utiliza cachés de npm/composer (ya habilitado).
 
 ## Troubleshooting
-- Checks no aparecen en el PR pero Actions está verde:
-  - Asegura “Required checks” configurados (arriba)
-  - Ejecuta manualmente con `workflow_dispatch`
-  - Cierra/reabre el PR o haz un commit vacío para re-disparar
+- Checks no aparecen:
+  - Ejecuta manualmente `ci` con `workflow_dispatch`.
+  - Haz un commit vacío para re-disparar: `git commit --allow-empty -m "chore(ci): trigger" && git push`.
 - Permisos:
-  - Settings → Actions → General: Allow all actions; GITHUB_TOKEN con read/write si lo requiere tu workflow
+  - Settings → Actions → General: permitir GitHub Actions y GITHUB_TOKEN por defecto.

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -1,0 +1,42 @@
+# Frontend: React 19 + Inertia 2 + shadcn/ui + Tailwind 4
+
+Guía rápida para el frontend del starter kit.
+
+## Estructura
+- Código en `resources/js/`
+- Componentes UI con shadcn/ui + Radix
+- Tipos en `resources/js/types/`
+- Utilidades en `resources/js/lib/`
+
+## Inertia 2
+- Props compartidas: autenticación, roles/permisos (`HandleInertiaRequests`).
+- Buenas prácticas:
+  - `useForm` para formularios
+  - `Link` con `prefetch`
+  - `deferred props` para cargas pesadas
+  - `polling` para datos en vivo
+
+## UI y estilos
+- Tailwind 4: usa `@import` en `resources/css/app.css`
+- shadcn/ui: componentes accesibles y composables
+- Recomendaciones:
+  - Componentes pequeños y tipados
+  - Reutilizar tokens/variables de diseño
+
+## Rendimiento
+- `React.lazy` para code splitting
+- Evitar renders innecesarios (memoización donde aplique)
+- Carga diferida de recursos no críticos
+
+## Testing de componentes
+- Vitest + RTL
+- Testear estados, accesibilidad y eventos
+
+## i18n
+- Usa `__()` helper desde backend con fallback a inglés
+- Componer textos desde props compartidas o endpoints dedicados
+
+## Seguridad
+- CSRF automático con Inertia/Laravel
+- Validaciones en backend + feedback en UI
+- Autorización en Policies y gates (no en componentes)

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,0 +1,77 @@
+# Permisos y Roles (Spatie)
+
+Esta guía concentra todo lo referente a `spatie/laravel-permission` para minimizar conflictos en `README.md`.
+
+## Instalación y Configuración
+- Paquete: `spatie/laravel-permission`.
+- Publicados: `config/permission.php` y migraciones del paquete.
+- Modelo `User` usa `Spatie\Permission\Traits\HasRoles`.
+- Aliases de middleware en `bootstrap/app.php`:
+  - `role`, `permission`, `role_or_permission`.
+
+## Seeding base
+- `database/seeders/BaseSystemSeeder.php` crea roles: `root`, `admin`, `standard`.
+- `database/seeders/DatabaseSeeder.php` lo invoca.
+- Comando de instalación: `php artisan app:install`.
+  - Con `--dev` crea usuarios demo con roles.
+  - Ejecuta `permission:cache-reset` al final.
+
+## Props compartidas (Inertia)
+En `App/Http/Middleware/HandleInertiaRequests` se comparten:
+- `auth.user`: usuario autenticado.
+- `auth.roles`: string[] con roles del usuario.
+- `auth.permissions`: string[] con permisos agregados.
+
+Ejemplo en React (`resources/js/pages/dashboard.tsx`):
+```tsx
+import { usePage } from '@inertiajs/react';
+
+type Props = {
+  auth: {
+    user: { name: string } | null;
+    roles: string[];
+    permissions: string[];
+  };
+};
+
+export default function Dashboard() {
+  const { props } = usePage<Props>();
+  const { roles } = props.auth;
+  const isAdmin = roles.includes('admin') || roles.includes('root');
+
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      {isAdmin && <div className="mt-4">Sección solo para Admin/Root</div>}
+    </div>
+  );
+}
+```
+
+## Protección de rutas
+`routes/web.php` (agrupada bajo `auth` + `verified`):
+```php
+Route::get('admin-only', function () {
+    return response('Admin area', 200);
+})->middleware(['role:admin|root'])->name('admin.only');
+```
+
+## Tests (Pest)
+- Sembrar roles antes de asignarlos:
+```php
+use Database\Seeders\BaseSystemSeeder;
+use function Pest\Laravel\artisan;
+
+artisan('db:seed', ['--class' => BaseSystemSeeder::class])->assertSuccessful();
+```
+- Ver ejemplos en `tests/Feature/Permissions/`.
+
+## Troubleshooting
+- Cambié roles/permisos y no se reflejan: ejecutar `php artisan permission:cache-reset`.
+- Conflictos de documentación: actualizar solo este archivo y enlazar desde `README.md`.
+
+## Buenas prácticas
+- Usar middleware `role:`/`permission:` para rutas.
+- Validar acciones con Policies para lógica de autorización más compleja.
+- Mantener nombres de roles en minúsculas y consistentes.
+- Evitar lógica de autorización en componentes; preferir helpers/gates centralizados.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,41 @@
+# Testing
+
+Guía de pruebas para el starter kit. Objetivo: 80%+ coverage, CI estable.
+
+## Backend (Pest v4)
+- Ejecutar local:
+```bash
+composer test        # alias que limpia cachés y corre Pest
+./vendor/bin/pest    # directo
+```
+- Estructura:
+  - `tests/Feature/` flujos completos (auth, permisos, settings…)
+  - `tests/Unit/` lógica aislada
+- Recomendaciones:
+  - Usa datasets para múltiples escenarios
+  - Usa factories y seeders mínimos
+  - Evita tocar disco/red salvo necesidad
+
+## Frontend
+- Vitest + React Testing Library (recomendado)
+  - Ubicar specs cerca del componente: `Component.test.tsx`
+  - Testear UI states y accesibilidad (roles/labels)
+
+## Cobertura
+- Backend (Pest + Xdebug en CI):
+```bash
+./vendor/bin/pest --coverage --min=80
+```
+- Frontend (Vitest):
+```bash
+npm run test -- --coverage
+```
+
+## Prácticas
+- Usa `given/when/then` en descripciones
+- Evita mocks globales excesivos; delimítalos por test
+- Añade pruebas primero en bugs reproducibles
+
+## Integración con CI
+- `tests.yml` ejecuta Pest tras build y migraciones SQLite
+- Subir umbral gradualmente (70→80→85) para no bloquear iteraciones tempranas


### PR DESCRIPTION
This PR centralizes documentation to reduce future merge conflicts and keeps README lean.

Changes:
- Add docs/permissions.md
- Add docs/testing.md
- Add docs/ci-cd.md
- Add docs/frontend.md
- Update README.md to link to the new docs

Rationale:
- Avoid concurrent edits in README.md.
- Modular docs per area, easier to evolve independently.

CI:
- Workflows should run on pull_request to develop.
- Both workflows support manual workflow_dispatch if needed.

After merge:
- Update local develop and delete feature branch (local/remote).